### PR TITLE
Add invoice extraction page using Gemini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your-gemini-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
+## Invoice Extractor
+
+Navigate to `/invoices` to try the invoice extraction tool. Paste invoice text, specify the fields you want to capture, and the page will display the extracted values in a table. You can export the result as a CSV file.
+
+### Environment Variables
+
+Create a `.env.local` file based on `.env.example` and add your Gemini API key:
+
+```bash
+cp .env.example .env.local
+# then edit .env.local and set GEMINI_API_KEY
+```
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/src/app/api/extract/route.js
+++ b/src/app/api/extract/route.js
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req) {
+  try {
+    const { invoiceText, fields } = await req.json();
+    if (!invoiceText || !Array.isArray(fields)) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: 'Missing GEMINI_API_KEY' }, { status: 500 });
+    }
+
+    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
+
+    const prompt = [
+      {
+        role: 'user',
+        parts: [
+          {
+            text: `Extract the following fields from this invoice:\nFields: ${fields.join(', ')}\nInvoice:\n${invoiceText}\nRespond with JSON mapping each field to a value. Use empty string for missing fields.`,
+          },
+        ],
+      },
+    ];
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ contents: prompt }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return NextResponse.json({ error: `Gemini API error: ${text}` }, { status: 500 });
+    }
+
+    const data = await response.json();
+    const content = data.candidates?.[0]?.content?.parts?.[0]?.text || '{}';
+    let result;
+    try {
+      result = JSON.parse(content);
+    } catch {
+      result = { error: 'Invalid JSON response', raw: content };
+    }
+
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json({ error: err.message });
+  }
+}

--- a/src/app/invoices/page.js
+++ b/src/app/invoices/page.js
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function Invoices() {
+  const [invoiceText, setInvoiceText] = useState('');
+  const [fields, setFields] = useState(['customer name', 'price', 'quantity']);
+  const [newField, setNewField] = useState('');
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const addField = () => {
+    if (newField.trim()) {
+      setFields([...fields, newField.trim()]);
+      setNewField('');
+    }
+  };
+
+  const removeField = (field) => {
+    setFields(fields.filter((f) => f !== field));
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/extract', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invoiceText, fields }),
+      });
+      const data = await res.json();
+      setResult(data);
+    } catch (err) {
+      setResult({ error: err.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const exportCsv = () => {
+    if (!result || typeof result !== 'object') return;
+    const headers = fields.join(',');
+    const values = fields.map((f) => JSON.stringify(result[f] || '')).join(',');
+    const csvContent = `${headers}\n${values}`;
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'invoice.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Invoice Extractor</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <textarea
+          rows={10}
+          style={{ width: '100%' }}
+          placeholder="Paste invoice text here"
+          value={invoiceText}
+          onChange={(e) => setInvoiceText(e.target.value)}
+        />
+      </div>
+      <div>
+        <ul>
+          {fields.map((field) => (
+            <li key={field} style={{ marginBottom: '4px' }}>
+              {field}{' '}
+              <button onClick={() => removeField(field)}>remove</button>
+            </li>
+          ))}
+        </ul>
+        <input
+          type="text"
+          placeholder="Add field"
+          value={newField}
+          onChange={(e) => setNewField(e.target.value)}
+        />
+        <button onClick={addField}>Add Field</button>
+      </div>
+      <button onClick={handleSubmit} disabled={loading} style={{ marginTop: '1rem' }}>
+        {loading ? 'Processing...' : 'Extract Fields'}
+      </button>
+      {result && (
+        <div style={{ marginTop: '2rem' }}>
+          <table border="1" cellPadding="4" style={{ borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {fields.map((f) => (
+                  <th key={f}>{f}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                {fields.map((f) => (
+                  <td key={f}>{result[f] || ''}</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+          <button onClick={exportCsv} style={{ marginTop: '1rem' }}>
+            Export CSV
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -18,6 +18,9 @@ export default function Home() {
             Get started by editing <code>src/app/page.js</code>.
           </li>
           <li>Save and see your changes instantly.</li>
+          <li>
+            <a href="/invoices">Go to Invoice Extractor</a>
+          </li>
         </ol>
 
         <div className={styles.ctas}>


### PR DESCRIPTION
## Summary
- create `.env.example`
- link `.env.example` in `.gitignore`
- add new API route to talk to the Gemini API
- add dynamic invoice extraction page with CSV export
- link new page from the homepage
- document the invoice extractor and env vars in README

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `GEMINI_API_KEY=dummy npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a9a22ede4832d943c9d5bd7fd6e5c