### PR TITLE
Add PDF upload feature for invoice extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can start editing the page by modifying `app/page.js`. The page auto-updates
 
 ## Invoice Extractor
 
-Navigate to `/invoices` to try the invoice extraction tool. Paste invoice text, specify the fields you want to capture, and the page will display the extracted values in a table. You can export the result as a CSV file.
+Navigate to `/invoices` to try the invoice extraction tool. Upload an invoice PDF, specify the fields you want to capture, and the page will display the extracted values in a table. You can export the result as a CSV file.
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "next": "15.3.3",
+    "pdfjs-dist": "^3.11.174"
   }
 }


### PR DESCRIPTION
## Summary
- allow PDF upload instead of textarea input
- parse PDF client-side using `pdfjs-dist`
- update README usage instructions
- add `pdfjs-dist` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aa0718798832db564bacba4e93f3c